### PR TITLE
mail: get_attachments returns correct filename when it is specified in content_type

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -235,10 +235,14 @@ defmodule Mail do
         filename =
           case List.wrap(Mail.Message.get_header(message, :content_disposition)) do
             [_ | properties] ->
-              Enum.find_value(properties, "Unknown", fn {key, value} ->
+              Enum.find_value(properties, fn {key, value} ->
                 key == "filename" && value
               end)
-          end
+          end ||
+            case Mail.Message.get_header(message, :content_type) do
+              [_, {"name", name}] -> name
+              _ -> "Unknown"
+            end
 
         {:cont, List.insert_at(acc, -1, {filename, message.body})}
       else

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -519,7 +519,7 @@ defmodule MailTest do
       assert attachment == file
     end
 
-    test "get_attachments handles content disposition header withot filename property" do
+    test "get_attachments handles content disposition header without filename property" do
       {_, data} = file = {"Unknown", File.read!("README.md")}
 
       mail =
@@ -527,6 +527,28 @@ defmodule MailTest do
         |> Mail.Message.put_body(data)
         |> Mail.Message.put_header(:content_disposition, [
           "attachment"
+        ])
+        |> Mail.Message.put_header(:content_transfer_encoding, :base64)
+        # We render and parse so we have the attachment with no properties
+        |> Mail.render()
+        |> Mail.parse()
+
+      [attachment | _] = Mail.get_attachments(mail)
+      assert attachment == file
+    end
+
+    test "get_attachments handles checks content_type for name property" do
+      {filename, data} = file = {"README.md", File.read!("README.md")}
+
+      mail =
+        Mail.build()
+        |> Mail.Message.put_body(data)
+        |> Mail.Message.put_header(:content_disposition, [
+          "attachment"
+        ])
+        |> Mail.Message.put_header(:content_type, [
+          "application/octet-stream",
+          {"name", filename}
         ])
         |> Mail.Message.put_header(:content_transfer_encoding, :base64)
         # We render and parse so we have the attachment with no properties


### PR DESCRIPTION
## Changes proposed in this pull request

Found in production, an e-mail with the following part:
```
Content-Type: application/octet-stream; name="document.pdf"
Content-Transfer-Encoding: base64
Content-Disposition: attachment
```

Currently, this returns filename "Unknown" since there is no `filename` property in `:content_disposition`.
This issue handles the case where the name is specified in `:content_type` instead.