### PR TITLE
Implement streaming RFC 2822 parser with nested multipart support

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -376,7 +376,7 @@ defmodule Mail.Parsers.RFC2822 do
     end)
   end
 
-  defp parse_headers(message, headers, opts) do
+  def parse_headers(message, headers, opts) do
     headers =
       Enum.reduce(headers, message.headers, fn header, headers ->
         {key, value} = parse_header(header, opts)
@@ -418,7 +418,7 @@ defmodule Mail.Parsers.RFC2822 do
   defp put_header(headers, key, value),
     do: Map.put(headers, key, value)
 
-  defp mark_multipart(message),
+  def mark_multipart(message),
     do: Map.put(message, :multipart, multipart?(message.headers))
 
   defp parse_header_value(key, " " <> value),
@@ -839,7 +839,7 @@ defmodule Mail.Parsers.RFC2822 do
     end
   end
 
-  defp decode(body, message, opts) do
+  def decode(body, message, opts) do
     content_type = message.headers["content-type"]
     charset = Mail.Proplist.get(content_type, "charset")
     transfer_encoding = Mail.Message.get_header(message, "content-transfer-encoding")

--- a/lib/mail/parsers/rfc_2822/parts_handler.ex
+++ b/lib/mail/parsers/rfc_2822/parts_handler.ex
@@ -1,0 +1,75 @@
+defmodule Mail.Parsers.RFC2822.PartsHandler do
+  @moduledoc """
+  Defines and invokes the `parts_handler_fn` callback used by RFC 2822 parsers.
+  The handler is a 2-arity function passed as `parts_handler_fn` in parser opts:
+      parts_handler_fn: fn message, opts -> ... end
+
+  It is called **once per part**, after the part's headers have been parsed but
+  **before** the body is read or decoded. The handler decides what to do with
+  the part body.
+
+  ### Arguments
+
+  | Argument  | Type            | Description |
+  |-----------|-----------------|-------------|
+  | `message` | `%Mail.Message{}` | Part with headers fully parsed. Body is `nil` at this point. |
+  | `opts`    | `keyword()`     | Options originally passed to `parse/2`, and extra opts depending on parser (see below). |
+
+  #### Extra opts injected by the parsers
+
+  | Key           | Type      | Available in         | Description |
+  |---------------|-----------|----------------------|-------------|
+  | `:part_index` | `integer` | both parsers         | 0-based index of this part within its multipart container. Resets to 0 for each nesting level. |
+  | `:part_size`  | `integer` | binary parser only   | Raw byte size of the part content (headers + body). Useful for skipping large attachments without reading them. |
+
+  ### Return values
+
+  | Return value          | Meaning |
+  |-----------------------|---------|
+  | `{:parse, message}`   | Parse the body normally and decode it. Use the returned `message` as the base (allows modifying headers before body parsing). |
+  | `{:skip, message}`    | Skip body parsing entirely. The returned `message` is used as-is — set `:body` to whatever you want (e.g., `nil`, `""`, or a placeholder). |
+
+  ## Examples
+
+  ### Filter by content-type or parts size
+
+      parts_handler_fn: fn message, _opts ->
+        content_type = List.first(Message.get_content_type(message) || [])
+        if content_type in @content_types_to_parse or part_info.size < @attachment_max_bytes_size do
+          {:parse, message}
+        else
+          {:skip, %{message | body: "[image removed]"}}
+        end
+      end
+
+  ### Annotate parts with their index
+
+      parts_handler_fn: fn message, opts ->
+        {:parse, put_in(message.headers["x-part-index"], opts[:part_index])}
+      end
+
+  """
+
+  alias Mail.Message
+
+  @doc false
+  def invoke(message, part_index, opts) do
+    with {:handler_fn, parts_handler_fn} when is_function(parts_handler_fn, 2) <-
+           {:handler_fn, Keyword.get(opts, :parts_handler_fn)},
+         handler_opts = Keyword.put(opts, :part_index, part_index),
+         {:result, {action, %Message{} = message}} when action in [:parse, :skip] <-
+           {:result, parts_handler_fn.(message, handler_opts)} do
+      {action, message}
+    else
+      {:handler_fn, nil} ->
+        {:parse, message}
+
+      {:handler_fn, _} ->
+        raise ArgumentError, "parts_handler_fn must be a function that accepts (message, opts)"
+
+      {:result, invalid_result} ->
+        raise ArgumentError,
+              "parts_handler_fn must return {:parse, message} or {:skip, message}. Got: #{inspect(invalid_result)}"
+    end
+  end
+end

--- a/lib/mail/parsers/rfc_2822_binary.ex
+++ b/lib/mail/parsers/rfc_2822_binary.ex
@@ -1,0 +1,328 @@
+defmodule Mail.Parsers.RFC2822Binary do
+  alias Mail.Parsers.RFC2822
+  alias Mail.Parsers.RFC2822.PartsHandler
+
+  @moduledoc ~S"""
+  RFC2822 Parser
+
+  Will attempt to parse a valid RFC2822 message back into
+  a `%Mail.Message{}` data model.
+
+  ## Examples
+
+      iex> message = \"""
+      ...> To: user@example.com\r
+      ...> From: me@example.com\r
+      ...> Subject: Test Email\r
+      ...> Content-Type: text/plain; foo=bar;\r
+      ...>   baz=qux;\r
+      ...> \r
+      ...> This is the body!\r
+      ...> It has more than one line\r
+      ...> \"""
+      iex> Mail.Parsers.RFC2822Binary.parse(message)
+      %Mail.Message{body: "This is the body!\r\nIt has more than one line", headers: %{"to" => ["user@example.com"], "from" => "me@example.com", "subject" => "Test Email", "content-type" => ["text/plain", {"foo", "bar"}, {"baz", "qux"}]}}
+  """
+
+  @doc """
+  Parses a RFC2822 message back into a `%Mail.Message{}` data model.
+
+  ## Options
+
+    * `:charset_handler` - A function that takes a charset and binary and returns a binary. Defaults to return the string as is.
+    * `:headers_only` - Whether to parse only the headers. Defaults to false.
+    * `:parts_handler_fn` - Callback invoked for each part of a multipart message,
+      after its headers are parsed and before its body is read. Injects
+      `opts[:part_index]` and `opts[:part_size]` (byte size of raw part content).
+      See `Mail.Parsers.RFC2822.PartsHandler` for the full callback contract.
+  """
+  @spec parse(binary() | nonempty_maybe_improper_list(), keyword()) :: Mail.Message.t()
+  def parse(content, opts \\ []) when is_binary(content) do
+    content =
+      if String.ends_with?(content, "\r\n"),
+        do: binary_part(content, 0, byte_size(content) - 2),
+        else: content
+
+    parse_part(%{
+      part_info: %{size: byte_size(content), start: 0, index: 0},
+      body_content: content,
+      call_handler: false,
+      opts: opts
+    })
+  end
+
+  defp parse_part(%{
+         part_info: part_info,
+         body_content: body_content,
+         call_handler: call_handler,
+         opts: opts
+       }) do
+    part_data = binary_part(body_content, part_info.start, part_info.size)
+    {headers, body_offset, has_body} = extract_headers_and_body_offset(part_data)
+
+    message =
+      %Mail.Message{}
+      |> RFC2822.parse_headers(headers, opts)
+      |> RFC2822.mark_multipart()
+
+    handler_result =
+      if call_handler do
+        opts_with_size = Keyword.put(opts, :part_size, part_info.size)
+        PartsHandler.invoke(message, part_info.index, opts_with_size)
+      else
+        {:parse, message}
+      end
+
+    apply_handler_result(handler_result, %{
+      has_body: has_body,
+      body_offset: body_offset,
+      part_data: part_data,
+      opts: opts
+    })
+  end
+
+  defp apply_handler_result({:skip, message}, _context) do
+    message
+  end
+
+  defp apply_handler_result({:parse, message}, %{has_body: false}) do
+    Map.put(message, :body, "")
+  end
+
+  defp apply_handler_result({:parse, message}, %{
+         body_offset: body_offset,
+         part_data: part_data,
+         opts: opts
+       }) do
+    body_content =
+      if body_offset < byte_size(part_data) do
+        part_data
+        |> binary_part(body_offset, byte_size(part_data) - body_offset)
+        # Strip the trailing CRLF that belongs to the boundary delimiter per RFC 2046
+        |> trim_line_ending()
+      else
+        ""
+      end
+
+    parse_body_binary(message, body_content, opts)
+  end
+
+  defp extract_headers_and_body_offset(content) do
+    content
+    |> Stream.unfold(fn remaining ->
+      case remaining |> :binary.split("\n") do
+        [""] -> nil
+        [line, rest] -> {{line, byte_size(line) + 1}, rest}
+        [line] -> {{line, byte_size(line)}, ""}
+      end
+    end)
+    |> Stream.map(fn {line, size} -> {trim_line_ending(line), size} end)
+    |> Enum.reduce_while({[], nil, 0, false}, &accumulate_headers/2)
+    |> case do
+      {headers, current_header, offset, false} ->
+        # No empty line found - all content is headers, no body section
+        headers = if current_header, do: [current_header | headers], else: headers
+        {Enum.reverse(headers), offset, false}
+
+      {headers, _current_header, offset, true} ->
+        # Empty line found normally - there is a body section (even if empty)
+        {headers, offset, true}
+    end
+  end
+
+  # Empty line marks end of headers
+  defp accumulate_headers({"", line_size}, {headers, current_header, offset, _found}) do
+    final_headers = if current_header, do: [current_header | headers], else: headers
+    {:halt, {Enum.reverse(final_headers), nil, offset + line_size, true}}
+  end
+
+  # Folded header (continuation line starts with space or tab)
+  defp accumulate_headers(
+         {<<first_char, _::binary>> = line, line_size},
+         {headers, current_header, offset, found}
+       )
+       when first_char in [?\s, ?\t] do
+    current_header = if current_header, do: current_header <> line, else: nil
+    {:cont, {headers, current_header, offset + line_size, found}}
+  end
+
+  # New header line
+  defp accumulate_headers({line, line_size}, {headers, current_header, offset, found}) do
+    new_headers = if current_header, do: [current_header | headers], else: headers
+    {:cont, {new_headers, line, offset + line_size, found}}
+  end
+
+  defp parse_body_binary(%Mail.Message{multipart: true} = message, body_content, opts) do
+    content_type = message.headers["content-type"]
+    boundary = Mail.Proplist.get(content_type, "boundary")
+    part_ranges = extract_parts_ranges(body_content, boundary)
+
+    parsed_parts =
+      part_ranges
+      |> Enum.with_index()
+      |> Enum.map(fn {{start, size}, index} ->
+        parse_part(%{
+          part_info: %{size: size, start: start, index: index},
+          body_content: body_content,
+          call_handler: true,
+          opts: opts
+        })
+      end)
+
+    case parsed_parts do
+      [] -> parse_body_binary(Map.put(message, :multipart, false), body_content, opts)
+      _ -> Map.put(message, :parts, parsed_parts)
+    end
+  end
+
+  # Empty body for non-multipart - set to empty string
+  defp parse_body_binary(%Mail.Message{multipart: false} = message, "", _opts) do
+    Map.put(message, :body, "")
+  end
+
+  # Empty body for multipart (shouldn't happen normally, but leave as nil)
+  defp parse_body_binary(%Mail.Message{} = message, "", _opts) do
+    message
+  end
+
+  # Simple (non-multipart) body
+  defp parse_body_binary(%Mail.Message{} = message, body_content, opts) do
+    # Normalize line endings without splitting into array
+    normalized_body = String.replace(body_content, ~r/\r?\n/, "\r\n")
+    decoded = RFC2822.decode(normalized_body, message, opts)
+    Map.put(message, :body, decoded)
+  end
+
+  defp extract_parts_ranges(content, boundary) do
+    start_boundary = "--" <> boundary
+    end_boundary = "--" <> boundary <> "--"
+
+    # Stream through content tracking byte offsets for boundaries
+    content
+    |> Stream.unfold(fn remaining ->
+      case remaining |> :binary.split("\n") do
+        [""] -> nil
+        [line, rest] -> {{line, byte_size(line) + 1}, rest}
+        [line] -> {{line, byte_size(line)}, ""}
+      end
+    end)
+    |> Stream.map(fn {line, size} -> {trim_line_ending(line), size} end)
+    |> Enum.reduce_while({[], 0, nil, nil}, fn {line, line_size}, {_, offset, _, _} = acc ->
+      new_offset = offset + line_size
+      accumulate_part_range({line, new_offset}, acc, start_boundary, end_boundary)
+    end)
+    |> extract_final_part_range(content)
+    |> Enum.reverse()
+  end
+
+  # End boundary found: but no part was started
+  defp accumulate_part_range(
+         {line, new_offset},
+         {ranges, _offset, _state, nil},
+         _start_boundary,
+         end_boundary
+       )
+       when line == end_boundary do
+    {:halt, {ranges, new_offset, :done, nil}}
+  end
+
+  # End boundary found: append new [part_start -> offset] range
+  defp accumulate_part_range(
+         {line, new_offset},
+         {ranges, offset, _state, part_start},
+         _start_boundary,
+         end_boundary
+       )
+       when line == end_boundary do
+    ranges = [{part_start, offset - part_start} | ranges]
+    {:halt, {ranges, new_offset, :done, nil}}
+  end
+
+  # Start boundary found: first boundary
+  defp accumulate_part_range(
+         {line, new_offset},
+         {ranges, _offset, nil, _part_start},
+         start_boundary,
+         _end_boundary
+       )
+       when line == start_boundary do
+    {:cont, {ranges, new_offset, :collecting, new_offset}}
+  end
+
+  # Start boundary found: subsequent boundary
+  defp accumulate_part_range(
+         {line, new_offset},
+         {ranges, offset, _state, part_start},
+         start_boundary,
+         _end_boundary
+       )
+       when line == start_boundary do
+    part_range = {part_start, offset - part_start}
+    {:cont, {[part_range | ranges], new_offset, :collecting, new_offset}}
+  end
+
+  # Inside a part: just track offset
+  defp accumulate_part_range(
+         {_line, new_offset},
+         {ranges, _offset, :collecting, part_start},
+         _start_boundary,
+         _end_boundary
+       ) do
+    {:cont, {ranges, new_offset, :collecting, part_start}}
+  end
+
+  # Before first boundary: ignore
+  defp accumulate_part_range(
+         {_line, new_offset},
+         {ranges, _offset, state, part_start},
+         _start_boundary,
+         _end_boundary
+       ) do
+    {:cont, {ranges, new_offset, state, part_start}}
+  end
+
+  # Handle case where end boundary wasn't found (still :collecting)
+  defp extract_final_part_range({ranges, _offset, :collecting, start}, content) do
+    # Add final part from start to end of content (if it has content (not empty or just whitespace)
+    part_size = byte_size(content) - start
+
+    if part_size > 0 and contains_non_whitespace?(content, start, start + part_size) do
+      [{start, part_size} | ranges]
+    else
+      ranges
+    end
+  end
+
+  defp extract_final_part_range({ranges, _offset, _state, _start}, _content) do
+    ranges
+  end
+
+  @whitespaces [?\s, ?\t, ?\r, ?\n]
+  defp contains_non_whitespace?(content, pos, limit) when pos < limit do
+    case :binary.at(content, pos) do
+      char when char in @whitespaces -> contains_non_whitespace?(content, pos + 1, limit)
+      _ -> true
+    end
+  end
+
+  defp contains_non_whitespace?(_, _, _), do: false
+
+  # Fast binary pattern matching for trimming \r\n, \n, or \r from the end of a line.
+  # Called after splitting on "\n", so lines only ever end with "\r" (CRLF input) or
+  # nothing (LF-only input). The \r\n and \n clauses handle edge cases defensively.
+  defp trim_line_ending(line) when is_binary(line), do: trim_line_ending(byte_size(line), line)
+
+  defp trim_line_ending(size, line)
+       when size >= 2 and binary_part(line, size - 2, 2) == "\r\n",
+       do: binary_part(line, 0, size - 2)
+
+  defp trim_line_ending(size, line)
+       when size >= 1 and binary_part(line, size - 1, 1) == "\n",
+       do: binary_part(line, 0, size - 1)
+
+  defp trim_line_ending(size, line)
+       when size >= 1 and binary_part(line, size - 1, 1) == "\r",
+       do: binary_part(line, 0, size - 1)
+
+  defp trim_line_ending(_, line), do: line
+end

--- a/lib/mail/parsers/rfc_2822_stream.ex
+++ b/lib/mail/parsers/rfc_2822_stream.ex
@@ -1,0 +1,556 @@
+defmodule Mail.Parsers.RFC2822Stream do
+  @moduledoc """
+  Streaming parser for RFC2822 email messages.
+
+  Processes email content line-by-line using a single-pass state machine, efficient for large
+  multipart messages.
+  """
+  alias Mail.Parsers.RFC2822
+  alias Mail.Parsers.RFC2822.PartsHandler
+  alias Mail.Message
+
+  defmodule StackEntry do
+    @moduledoc false
+    defstruct [:parent_message, :multipart_context]
+  end
+
+  alias Mail.Parsers.RFC2822Stream.State
+
+  @doc """
+  Parses an email into a `%Message{}` struct.
+
+  Accepts a binary (for retrocompatibility) or an enumerable (stream) of lines.
+
+  ## Options
+
+    * `:charset_handler` - Function to handle charset decoding.
+    * `:parts_handler_fn` - Callback invoked for each part of a multipart message,
+      after its headers are parsed and before its body is read. See
+      `Mail.Parsers.RFC2822.PartsHandler` for the full callback contract.
+  """
+
+  @spec parse(binary() | nonempty_maybe_improper_list() | Enumerable.t(), keyword()) ::
+          Message.t()
+  def parse(content, opts \\ []) do
+    content
+    |> to_stream()
+    |> parse_stream(opts)
+  end
+
+  # Converts a binary or enumerable of lines into a stream of lines for retrocompatibility.
+  # Lines are returned without line endings (trim_line_ending will handle any remaining \r\n)
+  defp to_stream(content) when is_binary(content) do
+    Stream.unfold(String.trim_trailing(content, "\r\n"), fn
+      "" ->
+        nil
+
+      remaining ->
+        case :binary.split(remaining, "\r\n") do
+          [line, rest] -> {line, rest}
+          [line] -> {line, ""}
+        end
+    end)
+  end
+
+  defp to_stream(content), do: content
+
+  # ==============================================================================
+  # Single-Pass State Machine
+  #
+  # States:
+  #   :root_headers   - Parsing main message headers
+  #   :root_body      - Collecting non-multipart message body
+  #   :preamble       - Between root headers and first boundary (discarded)
+  #   :part_headers   - Parsing a part's headers
+  #   :part_body      - Collecting a part's body (when handler returns :parse)
+  #   :skip_body      - Skipping a part's body (when handler returns Message)
+  #   :epilogue       - After end boundary (discarded)
+  # ==============================================================================
+
+  defp parse_stream(stream, opts) do
+    stream
+    |> Stream.map(&trim_line_ending/1)
+    |> Enum.reduce(State.new(opts), &process_line/2)
+    |> finalize_parsing()
+  end
+
+  # Fast binary pattern matching for trimming \r\n, \n, or \r
+  defp trim_line_ending(line) when is_binary(line), do: trim_line_ending(byte_size(line), line)
+
+  defp trim_line_ending(byte_size, line)
+       when byte_size >= 2 and binary_part(line, byte_size - 2, 2) == "\r\n",
+       do: binary_part(line, 0, byte_size - 2)
+
+  defp trim_line_ending(byte_size, line)
+       when byte_size >= 1 and binary_part(line, byte_size - 1, 1) == "\n",
+       do: binary_part(line, 0, byte_size - 1)
+
+  defp trim_line_ending(byte_size, line)
+       when byte_size >= 1 and binary_part(line, byte_size - 1, 1) == "\r",
+       do: binary_part(line, 0, byte_size - 1)
+
+  defp trim_line_ending(_, line), do: line
+
+  # ==============================================================================
+  # Line Processing Dispatch
+  # ==============================================================================
+
+  defp process_line(line, %State{phase: :root_headers} = state),
+    do: process_root_header(line, state)
+
+  defp process_line(line, %State{phase: :root_body} = state), do: process_root_body(line, state)
+  defp process_line(line, %State{phase: :preamble} = state), do: process_preamble(line, state)
+
+  defp process_line(line, %State{phase: :part_headers} = state),
+    do: process_part_header(line, state)
+
+  defp process_line(line, %State{phase: :part_body} = state), do: process_part_body(line, state)
+  defp process_line(line, %State{phase: :skip_body} = state), do: process_skip_body(line, state)
+  defp process_line(_line, %State{phase: :epilogue} = state), do: state
+
+  # ==============================================================================
+  # Root Headers State
+  # ==============================================================================
+
+  defp process_root_header("", state) do
+    # Empty line marks end of headers
+    finalize_headers(state.root_headers, state.root_current_header)
+    |> build_message(state.opts)
+    |> case do
+      %Message{multipart: true} = message -> transition_to_preamble(state, message)
+      %Message{multipart: false} = message -> transition_to_root_body(state, message)
+    end
+  end
+
+  defp process_root_header(<<first_char, _::binary>> = line, state)
+       when first_char in [?\s, ?\t] do
+    # Folded header continuation
+    current = if state.root_current_header, do: state.root_current_header <> line, else: line
+    %{state | root_current_header: current}
+  end
+
+  defp process_root_header(line, %State{root_current_header: nil} = state) do
+    # New header line (no current header to finalize)
+    %{state | root_current_header: line}
+  end
+
+  defp process_root_header(
+         line,
+         %State{root_current_header: current, root_headers: headers} = state
+       ) do
+    # New header line (finalize current header first)
+    %{state | root_headers: [current | headers], root_current_header: line}
+  end
+
+  # ==============================================================================
+  # Root Body State (non-multipart)
+  # ==============================================================================
+
+  defp process_root_body(line, state) do
+    %{state | root_body_buffer: [line | state.root_body_buffer]}
+  end
+
+  # ==============================================================================
+  # Preamble State
+  # ==============================================================================
+
+  defp process_preamble(line, state) do
+    case check_boundary(line, state) do
+      {:start_boundary, _} ->
+        %{
+          state
+          | phase: :part_headers,
+            part: %{state.part | headers: [], current_header: nil}
+        }
+
+      {:end_boundary, _} ->
+        %{state | phase: :epilogue}
+
+      # Accumulate preamble content for fallback body (if no parts found)
+      :none ->
+        %{state | root_body_buffer: [line | state.root_body_buffer]}
+    end
+  end
+
+  # ==============================================================================
+  # Part Headers State
+  # ==============================================================================
+
+  defp process_part_header("", state) do
+    # Empty line marks end of part headers
+    finish_part_headers(state)
+  end
+
+  defp process_part_header(line, state) do
+    case check_boundary(line, state) do
+      {:start_boundary, _} ->
+        state
+        |> finish_part_headers()
+        |> finalize_part()
+        # The line detected as boundary is for the NEXT part, needed initialization
+        |> Map.put(:phase, :part_headers)
+
+      {:end_boundary, _} ->
+        state
+        |> finish_part_headers()
+        |> finalize_part()
+        |> finalize_multipart_level()
+
+      :none ->
+        # Header line
+        {new_headers, new_current} =
+          accumulate_header(line, state.part.headers, state.part.current_header)
+
+        %{state | part: %{state.part | headers: new_headers, current_header: new_current}}
+    end
+  end
+
+  defp finish_part_headers(state) do
+    finalize_headers(state.part.headers, state.part.current_header)
+    |> build_message(state.opts)
+    |> PartsHandler.invoke(state.multipart.part_index, state.opts)
+    |> case do
+      {:parse, %Message{multipart: true} = message} ->
+        # Nested multipart - push current context to stack
+        push_multipart_context(state, message)
+
+      {:parse, %Message{multipart: false} = message} ->
+        transition_to_part_body(state, message)
+
+      {:skip, message} ->
+        transition_to_skip_body(state, message)
+    end
+  end
+
+  # ==============================================================================
+  # Part Body State
+  # ==============================================================================
+
+  defp process_part_body(line, state) do
+    case check_boundary(line, state) do
+      {:start_boundary, _} ->
+        # End of this part, start of next
+        state
+        |> finalize_part()
+        |> reset_part_state()
+
+      {:end_boundary, _} ->
+        # End of this part and end of multipart
+        state
+        |> finalize_part()
+        |> finalize_multipart_level()
+
+      :none ->
+        # Accumulate body line
+        %{state | part: %{state.part | body_buffer: [line | state.part.body_buffer]}}
+    end
+  end
+
+  # ==============================================================================
+  # Skip Body State (handler returned custom message or awaiting boundary after nested)
+  # ==============================================================================
+
+  defp process_skip_body(line, state) do
+    case check_boundary(line, state) do
+      {:start_boundary, _} ->
+        # End of skipped part (if any), start of next
+        state
+        |> finalize_skipped_part()
+        |> reset_part_state()
+
+      {:end_boundary, _} ->
+        # End of skipped part (if any) and end of multipart
+        state
+        |> finalize_skipped_part()
+        |> finalize_multipart_level()
+
+      :none ->
+        # Discard body line
+        state
+    end
+  end
+
+  # ==============================================================================
+  # Nested Multipart Support
+  # ==============================================================================
+
+  defp push_multipart_context(state, message) do
+    boundary = Mail.Proplist.get(message.headers["content-type"], "boundary")
+
+    # Store parent message and current multipart context in stack
+    entry = %StackEntry{
+      parent_message: message,
+      multipart_context: state.multipart
+    }
+
+    state
+    |> Map.put(:phase, :preamble)
+    |> Map.put(:stack, [entry | state.stack])
+    |> State.init_multipart(boundary)
+    |> State.reset_part()
+  end
+
+  defp finalize_multipart_level(state) do
+    # Current level parts are done.
+    all_parts = Enum.reverse(state.multipart.parts)
+
+    case state.stack do
+      [] ->
+        # Top level - done
+        %{state | phase: :epilogue, multipart: %{state.multipart | parts: all_parts}}
+
+      [%StackEntry{} = parent | rest_stack] ->
+        # Pop from stack, create nested message with parts
+        nested_message = Map.put(parent.parent_message, :parts, all_parts)
+
+        # Go to skip_body state to await next boundary.
+        # Restore parent multipart context, adding the nested message we just built.
+        %{
+          state
+          | phase: :skip_body,
+            stack: rest_stack,
+            multipart: %{
+              parent.multipart_context
+              | parts: [nested_message | parent.multipart_context.parts],
+                part_index: parent.multipart_context.part_index + 1
+            },
+            # part.pending_message is nil because we just finished strict parsing of a part
+            part: %{
+              state.part
+              | pending_message: nil
+            }
+        }
+    end
+  end
+
+  # ==============================================================================
+  # Part Finalization Logic
+  # ==============================================================================
+
+  defp finalize_part(state) do
+    part = decode_body(state.part.pending_message, state.part.body_buffer, state.opts)
+
+    %{
+      state
+      | multipart: %{
+          state.multipart
+          | parts: [part | state.multipart.parts],
+            part_index: state.multipart.part_index + 1
+        }
+    }
+  end
+
+  defp finalize_skipped_part(%State{part: %{pending_message: nil}} = state) do
+    # Already added (nested multipart case)
+    state
+  end
+
+  defp finalize_skipped_part(%State{part: %{pending_message: message}} = state) do
+    %{
+      state
+      | multipart: %{
+          state.multipart
+          | parts: [message | state.multipart.parts],
+            part_index: state.multipart.part_index + 1
+        },
+        part: %{state.part | pending_message: nil}
+    }
+  end
+
+  defp reset_part_state(state) do
+    state
+    |> Map.put(:phase, :part_headers)
+    |> State.reset_part()
+  end
+
+  # ==============================================================================
+  # Finalization
+  #
+  # Handles graceful termination when stream ends unexpectedly in any phase.
+  # Each clause handles a specific edge case based on parser state.
+  # ==============================================================================
+
+  defp finalize_parsing(%State{phase: :root_headers} = state) do
+    # Edge case: Stream ended before body started (email with only headers)
+    # Action: Build message from accumulated headers with empty body
+    headers = finalize_headers(state.root_headers, state.root_current_header)
+
+    headers
+    |> build_message(state.opts)
+    |> Map.put(:body, "")
+  end
+
+  defp finalize_parsing(%State{phase: :root_body} = state) do
+    # Normal case: Non-multipart message with body
+    # Action: Decode accumulated body buffer into message.body
+    state.root_message
+    |> put_decoded_body(state.root_body_buffer, state.opts)
+  end
+
+  defp finalize_parsing(
+         %State{phase: :preamble, multipart: %{parts: []}, root_body_buffer: []} = state
+       ) do
+    # Edge case: Multipart declared in headers but no boundary found, no preamble
+    # Action: Return message with empty parts list and empty body
+    state.root_message
+    |> Map.put(:parts, [])
+    |> Map.put(:body, "")
+  end
+
+  defp finalize_parsing(%State{phase: :preamble, multipart: %{parts: []}} = state) do
+    # Edge case: Multipart declared but no boundary found, preamble exists
+    # Action: Treat preamble as regular body, demote to non-multipart
+    state.root_message
+    |> put_decoded_body(state.root_body_buffer, state.opts)
+    |> Map.put(:multipart, false)
+  end
+
+  defp finalize_parsing(%State{phase: :epilogue, multipart: %{parts: parts}} = state) do
+    # Normal case: Multipart message ended cleanly and reached the final --boundary--
+    # Action: Build message with all collected parts
+    Map.put(state.root_message, :parts, parts)
+  end
+
+  defp finalize_parsing(
+         %State{phase: :part_headers, part: %{headers: [], current_header: nil}} = state
+       ) do
+    # Edge case: Stream ended at a trailing boundary with no content after
+    # Action: Don't add empty part, just return collected parts
+    build_multipart_message(state)
+  end
+
+  defp finalize_parsing(%State{phase: :part_headers} = state) do
+    # Edge case: Stream ended mid-way through parsing part headers
+    # Action: Finish incomplete headers and add partial part
+    state
+    |> finish_part_headers()
+    |> case do
+      %State{phase: :part_body} = state -> finalize_part(state)
+      state -> finalize_skipped_part(state)
+    end
+    |> build_multipart_message()
+  end
+
+  defp finalize_parsing(%State{phase: :part_body} = state) do
+    # Edge case: Stream ended while collecting part body
+    # Action: Finalize part with whatever body was collected so far
+    state
+    |> finalize_part()
+    |> build_multipart_message()
+  end
+
+  defp finalize_parsing(%State{phase: :skip_body} = state) do
+    # Edge case: Stream ended while handler was skipping part body
+    # Action: Finalize the skipped part (already has custom message from handler)
+    state
+    |> finalize_skipped_part()
+    |> build_multipart_message()
+  end
+
+  # ==============================================================================
+  # Helpers
+  # ==============================================================================
+
+  defp check_boundary(line, %{multipart: multipart}) do
+    cond do
+      line == multipart.start_boundary -> {:start_boundary, line}
+      line == multipart.end_boundary -> {:end_boundary, line}
+      true -> :none
+    end
+  end
+
+  defp finalize_headers(headers, current_header) do
+    final = if current_header, do: [current_header | headers], else: headers
+    Enum.reverse(final)
+  end
+
+  defp build_message(headers, opts) do
+    %Message{}
+    |> RFC2822.parse_headers(headers, opts)
+    |> RFC2822.mark_multipart()
+  end
+
+  defp decode_body(message, buffer, opts) do
+    case buffer do
+      [] -> Map.put(message, :body, "")
+      buffer -> put_decoded_body(message, buffer, opts)
+    end
+  end
+
+  defp accumulate_header(<<first_char, _::binary>> = line, headers, current_header)
+       when first_char in [?\s, ?\t] do
+    # Continuation
+    updated = if current_header, do: current_header <> line, else: line
+    {headers, updated}
+  end
+
+  defp accumulate_header(line, headers, current_header) do
+    # New header
+    new_headers = if current_header, do: [current_header | headers], else: headers
+    {new_headers, line}
+  end
+
+  defp build_multipart_message(%State{multipart: %{parts: parts}, root_message: root_message}) do
+    parts
+    |> Enum.reverse()
+    |> then(&Map.put(root_message, :parts, &1))
+  end
+
+  defp put_decoded_body(%Message{} = message, buffer, opts) when is_list(buffer) do
+    buffer
+    |> Enum.reverse()
+    |> Enum.join("\r\n")
+    |> RFC2822.decode(message, opts)
+    |> then(fn body ->
+      Map.put(message, :body, body)
+    end)
+  end
+
+  defp transition_to_root_body(state, message) do
+    %{
+      state
+      | phase: :root_body,
+        root_message: message,
+        root_headers: [],
+        root_current_header: nil
+    }
+  end
+
+  defp transition_to_preamble(state, message) do
+    boundary = Mail.Proplist.get(message.headers["content-type"], "boundary")
+
+    state
+    |> Map.put(:phase, :preamble)
+    |> Map.put(:root_message, message)
+    |> Map.put(:root_headers, [])
+    |> Map.put(:root_current_header, nil)
+    |> State.init_multipart(boundary)
+  end
+
+  defp transition_to_part_body(state, message) do
+    %{
+      state
+      | phase: :part_body,
+        part: %{
+          state.part
+          | headers: [],
+            current_header: nil,
+            pending_message: message,
+            body_buffer: []
+        }
+    }
+  end
+
+  defp transition_to_skip_body(state, message) do
+    %{
+      state
+      | phase: :skip_body,
+        part: %{
+          state.part
+          | headers: [],
+            current_header: nil,
+            pending_message: message
+        }
+    }
+  end
+end

--- a/lib/mail/parsers/rfc_2822_stream/state.ex
+++ b/lib/mail/parsers/rfc_2822_stream/state.ex
@@ -1,0 +1,78 @@
+defmodule Mail.Parsers.RFC2822Stream.State do
+  @moduledoc false
+
+  defstruct [
+    # Parser phase: :root_headers | :root_body | :preamble | :part_headers | :part_body | :skip_body | :epilogue
+    phase: :root_headers,
+    opts: [],
+
+    # Root message context
+    root_headers: [],
+    root_current_header: nil,
+    root_message: nil,
+    root_body_buffer: [],
+
+    # Multipart context
+    multipart: %{
+      boundary: nil,
+      start_boundary: nil,
+      end_boundary: nil,
+      parts: [],
+      part_index: 0
+    },
+
+    # Current part context
+    part: %{
+      headers: [],
+      current_header: nil,
+      pending_message: nil,
+      body_buffer: []
+    },
+
+    # Stack of parent multipart contexts
+    stack: []
+  ]
+
+  @doc """
+  Creates a new State struct.
+  """
+  def new(opts) do
+    %__MODULE__{
+      phase: :root_headers,
+      opts: opts
+    }
+  end
+
+  @doc """
+  Resets the part context for parsing the next part.
+  """
+  def reset_part(state) do
+    %{
+      state
+      | part: %{
+          state.part
+          | headers: [],
+            current_header: nil,
+            pending_message: nil,
+            body_buffer: []
+        }
+    }
+  end
+
+  @doc """
+  Initializes multipart context with the given boundary.
+  """
+  def init_multipart(state, boundary) do
+    %{
+      state
+      | multipart: %{
+          state.multipart
+          | boundary: boundary,
+            start_boundary: "--" <> boundary,
+            end_boundary: "--" <> boundary <> "--",
+            parts: [],
+            part_index: 0
+        }
+    }
+  end
+end

--- a/test/mail/parsers/rfc_2822_binary_test.exs
+++ b/test/mail/parsers/rfc_2822_binary_test.exs
@@ -1,0 +1,222 @@
+defmodule Mail.Parsers.RFC2822BinaryTest do
+  use ExUnit.Case, async: true
+  doctest Mail.Parsers.RFC2822Binary
+
+  test "handler can skip parts based on size" do
+    message =
+      parse_email(
+        """
+        Subject: Test
+        Content-Type: multipart/mixed; boundary=foo
+
+        --foo
+        Content-Type: text/plain
+
+        Small part
+        --foo
+        Content-Type: text/plain
+
+        This is a much larger part with lots of content that should be skipped
+        --foo--
+        """,
+        parts_handler_fn: fn msg, opts ->
+          if opts[:part_size] > 50 do
+            {:skip, %{msg | body: "[Skipped]"}}
+          else
+            {:parse, msg}
+          end
+        end
+      )
+
+    assert length(message.parts) == 2
+    [small_part, large_part] = message.parts
+
+    assert small_part.body == "Small part"
+    assert large_part.body == "[Skipped]"
+  end
+
+  test "handler can filter by content-type" do
+    message =
+      parse_email(
+        """
+        Subject: Test
+        Content-Type: multipart/mixed; boundary=foo
+
+        --foo
+        Content-Type: text/plain
+
+        Keep this
+        --foo
+        Content-Type: image/png
+
+        Skip this
+        --foo--
+        """,
+        parts_handler_fn: fn msg, _opts ->
+          content_type = Mail.Message.get_content_type(msg) |> List.first()
+
+          if String.starts_with?(content_type, "image/") do
+            {:skip, %{msg | body: "[Image removed]"}}
+          else
+            {:parse, msg}
+          end
+        end
+      )
+
+    assert length(message.parts) == 2
+    [text_part, image_part] = message.parts
+
+    assert text_part.body == "Keep this"
+    assert image_part.body == "[Image removed]"
+  end
+
+  test "handler receives correct part info" do
+    collected_info = Agent.start_link(fn -> [] end)
+    {:ok, pid} = collected_info
+
+    parse_email(
+      """
+      Subject: Test
+      Content-Type: multipart/mixed; boundary=foo
+
+      --foo
+      Content-Type: text/plain
+
+      Part 1
+      --foo
+      Content-Type: text/plain
+
+      Part 2
+      --foo--
+      """,
+      parts_handler_fn: fn msg, opts ->
+        Agent.update(pid, fn list ->
+          [%{index: opts[:part_index], size: opts[:part_size]} | list]
+        end)
+
+        {:parse, msg}
+      end
+    )
+
+    infos = Agent.get(pid, & &1) |> Enum.reverse()
+    Agent.stop(pid)
+
+    assert length(infos) == 2
+
+    [info1, info2] = infos
+    assert info1.index == 0
+    assert info2.index == 1
+    assert is_integer(info1.size)
+  end
+
+  test "handler with nested multipart" do
+    message =
+      parse_email(
+        """
+        Subject: Test
+        Content-Type: multipart/mixed; boundary=outer
+
+        --outer
+        Content-Type: multipart/alternative; boundary=inner
+
+        --inner
+        Content-Type: text/plain
+
+        Inner text
+        --inner--
+        --outer
+        Content-Type: application/pdf
+
+        Large PDF content
+        --outer--
+        """,
+        parts_handler_fn: fn msg, _opts ->
+          content_type = Mail.Message.get_content_type(msg) |> List.first()
+
+          if String.starts_with?(content_type, "application/") do
+            {:skip, %{msg | body: "[Binary skipped]"}}
+          else
+            {:parse, msg}
+          end
+        end
+      )
+
+    assert length(message.parts) == 2
+    [nested_part, pdf_part] = message.parts
+
+    # Nested multipart should still be parsed normally
+    assert nested_part.multipart == true
+    assert length(nested_part.parts) == 1
+
+    # PDF should be skipped
+    assert pdf_part.body == "[Binary skipped]"
+  end
+
+  # ============================================================================
+  # Comparison with RFC2822 Parser
+  # ============================================================================
+
+  test "produces same output as RFC2822 for simple message" do
+    email =
+      convert_crlf("""
+      Subject: Test
+      From: me@example.com
+
+      Body text
+      """)
+
+    binary_result = Mail.Parsers.RFC2822Binary.parse(email)
+    original_result = Mail.Parsers.RFC2822.parse(email)
+
+    assert binary_result.headers == original_result.headers
+    assert binary_result.body == original_result.body
+    assert binary_result.multipart == original_result.multipart
+  end
+
+  test "produces same output as RFC2822 for multipart message" do
+    email =
+      convert_crlf("""
+      Subject: Test
+      Content-Type: multipart/mixed; boundary=foo
+
+      --foo
+      Content-Type: text/plain
+
+      Part 1
+      --foo
+      Content-Type: text/html
+
+      <p>Part 2</p>
+      --foo--
+      """)
+
+    binary_result = Mail.Parsers.RFC2822Binary.parse(email)
+    original_result = Mail.Parsers.RFC2822.parse(email)
+
+    assert binary_result.headers == original_result.headers
+    assert binary_result.multipart == original_result.multipart
+    assert length(binary_result.parts) == length(original_result.parts)
+
+    Enum.zip(binary_result.parts, original_result.parts)
+    |> Enum.each(fn {bp, op} ->
+      assert bp.headers == op.headers
+      assert bp.body == op.body
+    end)
+  end
+
+  # ============================================================================
+  # Helper Functions
+  # ============================================================================
+
+  defp parse_email(email, opts) do
+    email
+    |> convert_crlf()
+    |> Mail.Parsers.RFC2822Binary.parse(opts)
+  end
+
+  defp convert_crlf(text) do
+    text
+    |> String.replace("\r\n", "\n")
+    |> String.replace("\n", "\r\n")
+  end
+end

--- a/test/mail/parsers/rfc_2822_stream_test.exs
+++ b/test/mail/parsers/rfc_2822_stream_test.exs
@@ -1,0 +1,247 @@
+defmodule Mail.Parsers.RFC2822StreamPartsHandlerTest do
+  use ExUnit.Case, async: true
+
+  doctest Mail.Parsers.RFC2822
+
+  describe "parts_handler_fn" do
+    @multi_part_message """
+    To: Test User <user@example.com>, Other User <other@example.com>
+    CC: The Dude <dude@example.com>, Batman <batman@example.com>
+    From: Me <me@example.com>
+    Subject: Test email
+    Mime-Version: 1.0
+    Content-Type: multipart/alternative; boundary=foobar
+
+    This is a multi-part message in MIME format
+    --foobar
+    Content-Type: text/plain
+
+    This is some text
+
+    --foobar
+    Content-Type: text/html
+
+    <h1>This is some HTML</h1>
+
+    --foobar
+    x-my-header: no body!
+
+    --foobar--
+    """
+
+    test "handler returning :parse parses parts normally" do
+      message =
+        parse_email(
+          @multi_part_message,
+          parts_handler_fn: fn message, _opts ->
+            {:parse, message}
+          end
+        )
+
+      assert message.body == nil
+      [text_part, html_part, headers_only_part] = message.parts
+
+      assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
+      assert text_part.body == "This is some text\r\n"
+
+      assert html_part.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
+      assert html_part.body == "<h1>This is some HTML</h1>\r\n"
+
+      assert headers_only_part.headers["x-my-header"] == "no body!"
+      assert headers_only_part.body == ""
+    end
+
+    test "handler returning custom message with skipped body" do
+      message =
+        parse_email(
+          @multi_part_message,
+          parts_handler_fn: fn message, _opts ->
+            {:skip, Map.put(message, :body, "[Headers only - body skipped]")}
+          end
+        )
+
+      assert message.body == nil
+      [text_part, html_part, headers_only_part] = message.parts
+
+      # Headers are still parsed
+      assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
+      # Body is replaced with placeholder
+      assert text_part.body =~ "[Headers only - body skipped]"
+
+      assert html_part.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
+      assert html_part.body =~ "[Headers only - body skipped]"
+
+      assert headers_only_part.headers["x-my-header"] == "no body!"
+      assert headers_only_part.body == "[Headers only - body skipped]"
+    end
+
+    test "handler returning custom message" do
+      message =
+        parse_email(
+          @multi_part_message,
+          parts_handler_fn: fn message, opts ->
+            part_index = opts[:part_index]
+
+            new_message = %Mail.Message{
+              body: "Custom body for part #{part_index}",
+              headers: Map.put(message.headers, "x-custom", "true")
+            }
+
+            {:skip, new_message}
+          end
+        )
+
+      assert message.body == nil
+      [text_part, html_part, headers_only_part] = message.parts
+
+      assert text_part.body == "Custom body for part 0"
+      assert text_part.headers["x-custom"] == "true"
+      assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
+
+      assert html_part.body == "Custom body for part 1"
+      assert html_part.headers["x-custom"] == "true"
+
+      assert headers_only_part.body == "Custom body for part 2"
+      assert headers_only_part.headers["x-custom"] == "true"
+    end
+
+    test "handler can access message and conditionally skip based on content-type" do
+      message =
+        parse_email(
+          @multi_part_message,
+          parts_handler_fn: fn message, _opts ->
+            content_type = message.headers["content-type"]
+            # Skip HTML parts
+            if List.first(content_type || []) == "text/html" do
+              {:skip, Map.put(message, :body, "[Headers only - body skipped]")}
+            else
+              {:parse, message}
+            end
+          end
+        )
+
+      [text_part, html_part, headers_only_part] = message.parts
+
+      # Text part should be parsed
+      assert text_part.body == "This is some text\r\n"
+
+      # HTML part should be skipped
+      assert html_part.body =~ "[Headers only - body skipped]"
+
+      # Headers-only part should be parsed
+      assert headers_only_part.body == ""
+    end
+
+    test "handler with nested parts correctly indexes" do
+      nested_message = """
+      Content-Type: multipart/mixed; boundary=outer
+
+      --outer
+      Content-Type: text/plain
+
+      Outer text 1
+
+      --outer
+      Content-Type: multipart/alternative; boundary=inner
+
+      --inner
+      Content-Type: text/plain
+
+      Inner text
+
+      --inner
+      Content-Type: text/html
+
+      Inner html
+
+      --inner--
+      --outer
+      Content-Type: text/plain
+
+      Outer text 2
+
+      --outer--
+      """
+
+      message =
+        parse_email(
+          nested_message,
+          parts_handler_fn: fn
+            %{multipart: true} = message, _opts ->
+              {:parse, message}
+
+            message, opts ->
+              {:skip, %{message | body: "Custom body for part #{opts[:part_index]}"}}
+          end
+        )
+
+      [text_part, %{parts: [inner_text_part, inner_html_part]}, text_part2] = message.parts
+
+      assert text_part.body == "Custom body for part 0"
+
+      assert inner_text_part.body == "Custom body for part 0"
+      assert inner_html_part.body == "Custom body for part 1"
+
+      assert text_part2.body == "Custom body for part 2"
+    end
+
+    test "handles parent boundary appearing in nested part body (boundary collision)" do
+      nested_message = """
+      Content-Type: multipart/mixed; boundary=outer
+
+      --outer
+      Content-Type: multipart/alternative; boundary=inner
+
+      --inner
+      Content-Type: text/plain
+
+      This text contains what looks like parent boundaries:
+      --outer
+      This should be part of the body, not a boundary.
+      --outer--
+      Still in the body.
+
+      --inner--
+      --outer
+      Content-Type: text/plain
+
+      Part after nested
+
+      --outer--
+      """
+
+      message =
+        parse_email(
+          nested_message,
+          parts_handler_fn: fn message, _opts ->
+            {:parse, message}
+          end
+        )
+
+      [nested_part, text_part] = message.parts
+
+      # The nested part should contain one inner part
+      assert nested_part.multipart == true
+      [inner_text_part] = nested_part.parts
+
+      # The inner part's body should include the parent boundary markers as content
+      assert inner_text_part.body ==
+               """
+               This text contains what looks like parent boundaries:
+               --outer
+               This should be part of the body, not a boundary.
+               --outer--
+               Still in the body.
+               """
+               |> convert_crlf()
+
+      # The outer level should still parse correctly
+      assert text_part.body == "Part after nested\r\n"
+    end
+  end
+
+  defp parse_email(email, opts),
+    do: email |> convert_crlf() |> Mail.Parsers.RFC2822Stream.parse(opts)
+
+  def convert_crlf(text), do: String.replace(text, "\n", "\r\n")
+end

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -1295,7 +1295,7 @@ defmodule Mail.Parsers.RFC2822Test do
   end
 
   defp parse_email(email, opts \\ []),
-    do: email |> convert_crlf |> Mail.Parsers.RFC2822Stream.parse(opts)
+    do: email |> convert_crlf |> Mail.Parsers.RFC2822Binary.parse(opts)
 
   defp parse_recipient(recipient),
     do: Mail.Parsers.RFC2822.parse_recipient_value(recipient)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -1295,7 +1295,7 @@ defmodule Mail.Parsers.RFC2822Test do
   end
 
   defp parse_email(email, opts \\ []),
-    do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse(opts)
+    do: email |> convert_crlf |> Mail.Parsers.RFC2822Stream.parse(opts)
 
   defp parse_recipient(recipient),
     do: Mail.Parsers.RFC2822.parse_recipient_value(recipient)


### PR DESCRIPTION
Refactor the experimental streaming parser to a finite state machine (FSM) design.
This enables **single-pass parsing of arbitrarily large emails**, with full support for **nested multipart structures** and **custom per-part handling**, without loading entire messages into memory.

## 1. High-Level Architecture

The parser is implemented as a **finite state machine (FSM)** operating over a lazy stream of lines.

* **Input**: A stream of text lines (file, socket, or in-memory string).
* **Process**: `Enum.reduce/3` consumes the stream, threading a mutable `State` struct.
* **Output**: A fully constructed `%Mail.Message{}` tree.

Unlike the legacy implementation, the parser does **not** pre-split the message by boundaries or read it entirely into memory. Boundaries are detected incrementally, allowing strictly linear processing and constant memory usage relative to message size.

## 2. The State Struct

The `State` struct centralizes all parser context. It can be viewed as three logical layers:

1. **Root Context**
   Tracks parsing of the top-level message (headers, body, and final message).

2. **Current Part Context**
   Represents the part currently being parsed within a multipart section.

3. **Recursion Stack**
   Stores suspended multipart contexts to support arbitrary nesting.

## 3. State Machine Lifecycle

The FSM transitions through the following phases:

1. `:root_headers` – Read top-level headers.
2. `:preamble` – Discard (or buffer) text before the first boundary.
3. `:part_headers` – Read headers for a multipart part.
4. `:part_body` – Read and buffer body lines.
5. `:skip_body` – Ignore body lines when a handler takes ownership.
6. `:epilogue` – Discard text after the final boundary.
7. `:root_body` – Non-multipart fallback: consume the remaining stream as body.

## 4. Worked Example: Nested Multipart Parsing

The table below walks through a nested multipart message line by line.
Assume `parts_handler_fn/2` returns `{:skip, message}` for simple parts to avoid buffering large bodies.


| Input | Phase | Action & Result |
| ----- | ----- | --------------- |
| `From: sender@example.com`<br>`To: recipient@example.com`<br>`Content-Type: multipart/mixed;`<br>`  boundary="outer"`<br>`(empty line)` | `:root_headers` | Buffering headers... Empty line detected!<br>→ Parse headers, detect multipart, and `outer` boundary<br>→ Transition to `:preamble`<br>**Stack:** `[]` |
| `This is preamble text` | `:preamble` | Buffering preamble (discarded) |
| `--outer` | `:preamble` | **START BOUNDARY** detected!<br>→ Transition to `:part_headers` |
| `Content-Type: text/plain`<br>`Content-Disposition: attachment`<br>`(empty line)` | `:part_headers` | Buffering part headers... Empty line detected!<br>→ Parse headers, call handler<br>→ Handler returns `{:skip, msg}`<br>→ Transition to `:skip_body` |
| `This is Part A body content`<br>`Multiple lines here...`<br>`More content...` | `:skip_body` | Discarding lines |
| `--outer` | `:skip_body` | **START BOUNDARY** detected!<br>→ Finalize Part A<br>→ Parts: `[Part A]`<br>→ Transition to `:part_headers` |
| `Content-Type: multipart/alternative;`<br>`  boundary="inner"`<br>`(empty line)` | `:part_headers` | Buffering part headers... Empty line detected!<br>→ Parse headers, call handler<br>→ Handler returns `{:parse, msg}`<br>→ **NESTED MULTIPART** detected!<br><br>**PUSH TO STACK:**<br>• Save parent boundary=`"outer"`<br>• Save parent parts=`[Part A]`<br><br>**Stack:** `[{boundary:"outer", parts:[Part A]}]`<br>→ Switch to inner boundary=`"inner"`<br>→ Transition to `:preamble` |
| `Nested preamble text` | `:preamble`<br>(nested) | Current boundary: `"inner"`<br>Buffering preamble (discarded) |
| `--inner` | `:preamble` | **START BOUNDARY** detected!<br>→ Transition to `:part_headers` |
| `Content-Type: text/html`<br>`(empty line)` | `:part_headers` | Buffering nested part headers...<br>→ Handler returns `{:skip, msg}`<br>→ Transition to `:skip_body` |
| `<html>Nested part body</html>` | `:skip_body` | Discarding lines... |
| `--inner--` | `:skip_body` | **END BOUNDARY** detected!<br>→ Finalize nested part<br>→ Nested parts: `[HTML Part]`<br><br>**POP FROM STACK:**<br>• Restore boundary=`"outer"`<br>• Create nested message with parts<br>• Add to parent parts list<br><br>**Stack:** `[]`<br>**Parts:** `[Part A, Nested Message{parts:[HTML]}]`<br>→ Transition to `:skip_body` (wait for parent boundary) |
| `Epilogue of nested part` | `:skip_body` | Current boundary: `"outer"`<br>Discarding until parent boundary... |
| `--outer--` | `:skip_body` | **END BOUNDARY** detected!<br>Stack is empty (top level)<br>→ Transition to `:epilogue` |
| `Epilogue text after all parts` | `:epilogue` | Discarding all remaining lines... |

**END OF STREAM**
